### PR TITLE
[BUGFIX] Upgrade PHPExcel for PHP 7.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-3.0+",
 	"require":{
 		"typo3/flow":"*",
-		"phpoffice/phpexcel": "1.7.9"
+		"phpoffice/phpexcel": "1.8.1"
 	},
 	"autoload":{
 		"psr-0":{


### PR DESCRIPTION
PHPExcel 1.8.1 is fully compatible with PHP 7.0 and restores functionality for current PHP versions.